### PR TITLE
Version 1.4.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,26 @@
-BSD 3-Clause License
-
-Copyright (c) 2023, sbe15
-
+Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+All rights reserved.
+ *
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the Institute nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+ *
+THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Fork of Adam Dunkels Protothreads (https://dunkels.com/adam/pt/) with some funct
   This allows you to group multiple PT statements into a single macro,
   which would previously fail as multiple `LC_SET` would occur on the
   same line, thus creating duplicate case labels.
+
+* pt.h: Mark `PT_YIELD_FLAG` as potentially unused in PT_BEGIN.
+  
+  It seems that recent compilers report `PT_YIELD_FLAG` as 
+  'set, but not used' if no PT_YIELD (or variants) are used.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # protothreads
 Fork of Adam Dunkels Protothreads (https://dunkels.com/adam/pt/) with some functional updates.
+
+## 1.4.1
+* lc-switch.h: Use `__COUNTER__` instead of `__LINE__`.
+  
+  This allows you to group multiple PT statements into a single macro,
+  which would previously fail as multiple `LC_SET` would occur on the
+  same line, thus creating duplicate case labels.

--- a/lc-switch.h
+++ b/lc-switch.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023, Sebastian Esch
+ *
  * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
  * All rights reserved.
  *
@@ -29,6 +31,7 @@
  * This file is part of the Contiki operating system.
  *
  * Author: Adam Dunkels <adam@sics.se>
+ * Modifications: Sebastian Esch <https://github.com/sbe15/protothreads>
  *
  * $Id: lc-switch.h,v 1.4 2006/06/03 11:29:43 adam Exp $
  */
@@ -67,7 +70,10 @@ typedef unsigned short lc_t;
 
 #define LC_RESUME(s) switch(s) { case 0:
 
-#define LC_SET(s) s = __LINE__; case __LINE__:
+// Old: (will crash on multiple LC_SET occurances on the same line)
+// #define LC_SET(s) s = __LINE__; case __LINE__:
+// New: (produces monotonic labels, note that both expressions evaluate to the same value)
+#define LC_SET(s) s = __COUNTER__+1; case __COUNTER__:
 
 #define LC_END(s) }
 

--- a/pt.h
+++ b/pt.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023, Sebastian Esch
+ *
  * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
  * All rights reserved.
  *
@@ -29,6 +31,7 @@
  * This file is part of the Contiki operating system.
  *
  * Author: Adam Dunkels <adam@sics.se>
+ * Modifications by Sebastian Esch <https://github.com/sbe15/protothreads>
  *
  * $Id: pt.h,v 1.7 2006/10/02 07:52:56 adam Exp $
  */
@@ -112,7 +115,10 @@ struct pt {
  *
  * \hideinitializer
  */
-#define PT_BEGIN(pt) { char PT_YIELD_FLAG = 1; LC_RESUME((pt)->lc)
+// Old: (will produce a compiler warning if no PT_YIELD statement is used)
+// #define PT_BEGIN(pt) { char PT_YIELD_FLAG = 1; LC_RESUME((pt)->lc)
+// New: (mark PT_YIELD_FLAG as potentially unused)
+#define PT_BEGIN(pt) { char PT_YIELD_FLAG = 1; (void)PT_YIELD_FLAG; LC_RESUME((pt)->lc)
 
 /**
  * Declare the end of a protothread.


### PR DESCRIPTION
* lc-switch.h: Use '\_\_COUNTER\_\_' instead of '\_\_LINE\_\_'
* pt.h: Mark 'PT_YIELD_FLAG' as potentially unused in PT_BEGIN